### PR TITLE
Set theme to NoActionBar

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.ExcellentWiFi" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.ExcellentWiFi" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.ExcellentWiFi" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.ExcellentWiFi" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>


### PR DESCRIPTION
Changed the parent theme of the application to `Theme.MaterialComponents.DayNight.NoActionBar` to remove the action bar.

This change was applied to both the regular theme and the night theme.