### PR TITLE
Feature: Add WiFi and Bluetooth management tabs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Permissions for WiFi -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+
+    <!-- Permissions for Bluetooth -->
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/gorhaf/excellentwifi/BluetoothFragment.kt
+++ b/app/src/main/java/com/gorhaf/excellentwifi/BluetoothFragment.kt
@@ -1,0 +1,77 @@
+package com.gorhaf.excellentwifi
+
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import com.gorhaf.excellentwifi.databinding.FragmentBluetoothBinding
+
+class BluetoothFragment : Fragment() {
+
+    private var _binding: FragmentBluetoothBinding? = null
+    private val binding get() = _binding!!
+    private val bluetoothAdapter: BluetoothAdapter? by lazy { BluetoothAdapter.getDefaultAdapter() }
+
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (isGranted) {
+                updateBluetoothSwitch()
+            } else {
+                // Handle the case where the user denies the permission.
+                // For now, we'll just leave the switch as is.
+            }
+        }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentBluetoothBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        checkPermissionAndSetSwitch()
+    }
+
+    private fun checkPermissionAndSetSwitch() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            when {
+                ContextCompat.checkSelfPermission(
+                    requireContext(),
+                    Manifest.permission.BLUETOOTH_CONNECT
+                ) == PackageManager.PERMISSION_GRANTED -> {
+                    updateBluetoothSwitch()
+                }
+                else -> {
+                    requestPermissionLauncher.launch(Manifest.permission.BLUETOOTH_CONNECT)
+                }
+            }
+        } else {
+            updateBluetoothSwitch()
+        }
+    }
+
+    private fun updateBluetoothSwitch() {
+        // The BLUETOOTH_CONNECT permission is required to check isEnabled().
+        // Since we are checking for it, we can suppress the lint warning.
+        try {
+            binding.bluetoothSwitch.isChecked = bluetoothAdapter?.isEnabled == true
+        } catch (e: SecurityException) {
+            // This should not happen if permission is granted, but as a safeguard.
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/gorhaf/excellentwifi/MainActivity.kt
+++ b/app/src/main/java/com/gorhaf/excellentwifi/MainActivity.kt
@@ -2,7 +2,7 @@ package com.gorhaf.excellentwifi
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.widget.TextView
+import androidx.fragment.app.Fragment
 import com.gorhaf.excellentwifi.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
@@ -15,8 +15,25 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // Example of a call to a native method
-        binding.sampleText.text = stringFromJNI()
+        // Load the default fragment
+        loadFragment(WifiFragment())
+        binding.bottomNavigation.selectedItemId = R.id.nav_wifi
+
+        binding.bottomNavigation.setOnItemSelectedListener { item ->
+            val selectedFragment: Fragment = when (item.itemId) {
+                R.id.nav_wifi -> WifiFragment()
+                R.id.nav_bluetooth -> BluetoothFragment()
+                else -> WifiFragment()
+            }
+            loadFragment(selectedFragment)
+            true
+        }
+    }
+
+    private fun loadFragment(fragment: Fragment) {
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, fragment)
+            .commit()
     }
 
     /**

--- a/app/src/main/java/com/gorhaf/excellentwifi/WifiFragment.kt
+++ b/app/src/main/java/com/gorhaf/excellentwifi/WifiFragment.kt
@@ -1,0 +1,36 @@
+package com.gorhaf.excellentwifi
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.gorhaf.excellentwifi.databinding.FragmentWifiBinding
+
+class WifiFragment : Fragment() {
+
+    private var _binding: FragmentWifiBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentWifiBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val wifiManager = requireContext().applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        binding.wifiSwitch.isChecked = wifiManager.isWifiEnabled
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,14 +6,22 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
-        android:id="@+id/sample_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_navigation"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_navigation"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:menu="@menu/bottom_nav_menu" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_bluetooth.xml
+++ b/app/src/main/res/layout/fragment_bluetooth.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Switch
+        android:id="@+id/bluetooth_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="@string/bluetooth_status" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_wifi.xml
+++ b/app/src/main/res/layout/fragment_wifi.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Switch
+        android:id="@+id/wifi_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="@string/wifi_status" />
+
+</RelativeLayout>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/nav_wifi"
+        android:title="@string/tab_wifi" />
+
+    <item
+        android:id="@+id/nav_bluetooth"
+        android:title="@string/tab_bluetooth" />
+
+</menu>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.ExcellentWiFi" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.ExcellentWiFi" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">ExcellentWiFi</string>
+    <string name="tab_wifi">WiFi管理</string>
+    <string name="tab_bluetooth">蓝牙管理</string>
+    <string name="wifi_status">WiFi Status</string>
+    <string name="bluetooth_status">Bluetooth Status</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.ExcellentWiFi" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.ExcellentWiFi" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>


### PR DESCRIPTION
This change introduces a bottom navigation bar with two tabs: "WiFi Management" and "Bluetooth Management".

- Each tab opens a fragment that displays the status of the corresponding service (WiFi or Bluetooth) using a switch.
- Necessary permissions for accessing WiFi and Bluetooth states have been added to the AndroidManifest.xml.
- Runtime permission handling for `BLUETOOTH_CONNECT` is implemented for Android 12 and above.
- All user-visible strings are externalized to `strings.xml`.