### PR TITLE
feat: Add Bluetooth and WiFi scanning functionality

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,11 +5,22 @@
     <!-- Permissions for WiFi -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+
 
     <!-- Permissions for Bluetooth -->
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <!-- Request legacy Bluetooth permissions on older devices. -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <!-- Needed for Bluetooth scanning on API 31+ -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <!-- Needed for connecting to paired Bluetooth devices on API 31+ -->
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+
+    <!-- Common permission for both WiFi and Bluetooth scanning -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
 
     <application

--- a/app/src/main/java/com/gorhaf/excellentwifi/BluetoothFragment.kt
+++ b/app/src/main/java/com/gorhaf/excellentwifi/BluetoothFragment.kt
@@ -2,13 +2,21 @@ package com.gorhaf.excellentwifi
 
 import android.Manifest
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.gorhaf.excellentwifi.databinding.FragmentBluetoothBinding
@@ -18,16 +26,45 @@ class BluetoothFragment : Fragment() {
     private var _binding: FragmentBluetoothBinding? = null
     private val binding get() = _binding!!
     private val bluetoothAdapter: BluetoothAdapter? by lazy { BluetoothAdapter.getDefaultAdapter() }
+    private lateinit var deviceListAdapter: ArrayAdapter<String>
+    private val discoveredDevices = mutableListOf<String>()
 
-    private val requestPermissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
-            if (isGranted) {
+    private val permissionsLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            val allPermissionsGranted = permissions.entries.all { it.value }
+            if (allPermissionsGranted) {
                 updateBluetoothSwitch()
+                startScan()
             } else {
-                // Handle the case where the user denies the permission.
-                // For now, we'll just leave the switch as is.
+                Toast.makeText(requireContext(), "Permissions are required for Bluetooth functionality.", Toast.LENGTH_SHORT).show()
             }
         }
+
+    private val discoveryReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            when (intent.action) {
+                BluetoothDevice.ACTION_FOUND -> {
+                    val device: BluetoothDevice? = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE)
+                    device?.let {
+                        if (ActivityCompat.checkSelfPermission(
+                                requireContext(),
+                                Manifest.permission.BLUETOOTH_CONNECT
+                            ) != PackageManager.PERMISSION_GRANTED
+                        ) {
+                            // Permissions are already checked before starting scan, but this is a safeguard
+                            return
+                        }
+                        val deviceName = it.name ?: "Unknown Device"
+                        val deviceInfo = "$deviceName\n${it.address}"
+                        if (!discoveredDevices.contains(deviceInfo)) {
+                            discoveredDevices.add(deviceInfo)
+                            deviceListAdapter.notifyDataSetChanged()
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -39,21 +76,62 @@ class BluetoothFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        deviceListAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, discoveredDevices)
+        binding.devicesListView.adapter = deviceListAdapter
+
+        binding.scanButton.setOnClickListener {
+            checkPermissionsAndScan()
+        }
+
         checkPermissionAndSetSwitch()
+    }
+
+    private fun checkPermissionsAndScan() {
+        val requiredPermissions = mutableListOf<String>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            requiredPermissions.add(Manifest.permission.BLUETOOTH_SCAN)
+            requiredPermissions.add(Manifest.permission.BLUETOOTH_CONNECT)
+        } else {
+            requiredPermissions.add(Manifest.permission.BLUETOOTH)
+            requiredPermissions.add(Manifest.permission.BLUETOOTH_ADMIN)
+            requiredPermissions.add(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+
+        val permissionsToRequest = requiredPermissions.filter {
+            ContextCompat.checkSelfPermission(requireContext(), it) != PackageManager.PERMISSION_GRANTED
+        }
+
+        if (permissionsToRequest.isEmpty()) {
+            startScan()
+        } else {
+            permissionsLauncher.launch(permissionsToRequest.toTypedArray())
+        }
+    }
+
+    private fun startScan() {
+        if (ActivityCompat.checkSelfPermission(
+                requireContext(),
+                Manifest.permission.BLUETOOTH_SCAN
+            ) != PackageManager.PERMISSION_GRANTED && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        ) {
+            // This check is mainly for the IDE, as permissions are handled by checkPermissionsAndScan
+            return
+        }
+        if (bluetoothAdapter?.isDiscovering == true) {
+            bluetoothAdapter?.cancelDiscovery()
+        }
+        discoveredDevices.clear()
+        deviceListAdapter.notifyDataSetChanged()
+        bluetoothAdapter?.startDiscovery()
+        Toast.makeText(requireContext(), "Scanning for devices...", Toast.LENGTH_SHORT).show()
     }
 
     private fun checkPermissionAndSetSwitch() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            when {
-                ContextCompat.checkSelfPermission(
-                    requireContext(),
-                    Manifest.permission.BLUETOOTH_CONNECT
-                ) == PackageManager.PERMISSION_GRANTED -> {
-                    updateBluetoothSwitch()
-                }
-                else -> {
-                    requestPermissionLauncher.launch(Manifest.permission.BLUETOOTH_CONNECT)
-                }
+            if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
+                permissionsLauncher.launch(arrayOf(Manifest.permission.BLUETOOTH_CONNECT))
+            } else {
+                updateBluetoothSwitch()
             }
         } else {
             updateBluetoothSwitch()
@@ -61,13 +139,33 @@ class BluetoothFragment : Fragment() {
     }
 
     private fun updateBluetoothSwitch() {
-        // The BLUETOOTH_CONNECT permission is required to check isEnabled().
-        // Since we are checking for it, we can suppress the lint warning.
         try {
-            binding.bluetoothSwitch.isChecked = bluetoothAdapter?.isEnabled == true
+            if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                binding.bluetoothSwitch.isChecked = bluetoothAdapter?.isEnabled == true
+            }
         } catch (e: SecurityException) {
-            // This should not happen if permission is granted, but as a safeguard.
+            // Should not happen
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val filter = IntentFilter(BluetoothDevice.ACTION_FOUND)
+        requireActivity().registerReceiver(discoveryReceiver, filter)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        requireActivity().unregisterReceiver(discoveryReceiver)
+        if (ActivityCompat.checkSelfPermission(
+                requireContext(),
+                Manifest.permission.BLUETOOTH_SCAN
+            ) != PackageManager.PERMISSION_GRANTED && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        ) {
+            // Handled by permissions check
+            return
+        }
+        bluetoothAdapter?.cancelDiscovery()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/gorhaf/excellentwifi/WifiFragment.kt
+++ b/app/src/main/java/com/gorhaf/excellentwifi/WifiFragment.kt
@@ -1,11 +1,21 @@
 package com.gorhaf.excellentwifi
 
+import android.Manifest
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.net.wifi.ScanResult
 import android.net.wifi.WifiManager
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.gorhaf.excellentwifi.databinding.FragmentWifiBinding
 
@@ -13,6 +23,31 @@ class WifiFragment : Fragment() {
 
     private var _binding: FragmentWifiBinding? = null
     private val binding get() = _binding!!
+    private lateinit var wifiManager: WifiManager
+    private lateinit var wifiListAdapter: ArrayAdapter<String>
+    private val wifiNetworks = mutableListOf<String>()
+
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (isGranted) {
+                startWifiScan()
+            } else {
+                Toast.makeText(requireContext(), "Location permission is required for WiFi scanning.", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+    private val wifiScanReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action == WifiManager.SCAN_RESULTS_AVAILABLE_ACTION) {
+                val success = intent.getBooleanExtra(WifiManager.EXTRA_RESULTS_UPDATED, false)
+                if (success) {
+                    scanSuccess()
+                } else {
+                    scanFailure()
+                }
+            }
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -24,13 +59,54 @@ class WifiFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        val wifiManager = requireContext().applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        wifiManager = requireContext().applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
         binding.wifiSwitch.isChecked = wifiManager.isWifiEnabled
+
+        wifiListAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, wifiNetworks)
+        binding.wifiListView.adapter = wifiListAdapter
+
+        binding.scanButtonWifi.setOnClickListener {
+            checkPermissionAndScan()
+        }
+
+        val intentFilter = IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION)
+        requireContext().registerReceiver(wifiScanReceiver, intentFilter)
+    }
+
+    private fun checkPermissionAndScan() {
+        if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+            startWifiScan()
+        } else {
+            requestPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
+
+    private fun startWifiScan() {
+        wifiNetworks.clear()
+        wifiListAdapter.notifyDataSetChanged()
+        val success = wifiManager.startScan()
+        if (!success) {
+            scanFailure()
+        }
+        Toast.makeText(requireContext(), "Scanning for WiFi networks...", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun scanSuccess() {
+        val results: List<ScanResult> = wifiManager.scanResults
+        wifiNetworks.clear()
+        for (result in results) {
+            wifiNetworks.add("${result.SSID} - ${result.level}")
+        }
+        wifiListAdapter.notifyDataSetChanged()
+    }
+
+    private fun scanFailure() {
+        Toast.makeText(requireContext(), "WiFi scan failed.", Toast.LENGTH_SHORT).show()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
+        requireContext().unregisterReceiver(wifiScanReceiver)
         _binding = null
     }
 }

--- a/app/src/main/res/layout/fragment_bluetooth.xml
+++ b/app/src/main/res/layout/fragment_bluetooth.xml
@@ -1,13 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:padding="16dp">
 
     <Switch
         android:id="@+id/bluetooth_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
         android:text="@string/bluetooth_status" />
+
+    <Button
+        android:id="@+id/scan_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/bluetooth_switch"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="16dp"
+        android:text="Scan for Devices" />
+
+    <ListView
+        android:id="@+id/devices_list_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/scan_button"
+        android:layout_marginTop="16dp" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_wifi.xml
+++ b/app/src/main/res/layout/fragment_wifi.xml
@@ -1,13 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:padding="16dp">
 
     <Switch
         android:id="@+id/wifi_switch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
         android:text="@string/wifi_status" />
+
+    <Button
+        android:id="@+id/scan_button_wifi"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/wifi_switch"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="16dp"
+        android:text="Scan for Networks" />
+
+    <ListView
+        android:id="@+id/wifi_list_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/scan_button_wifi"
+        android:layout_marginTop="16dp" />
 
 </RelativeLayout>


### PR DESCRIPTION
- Adds a scan button and a list view to the Bluetooth screen to display discovered devices.
- Implements Bluetooth device discovery and permission handling.
- Adds a scan button and a list view to the WiFi screen to display available networks.
- Implements WiFi network scanning and permission handling.
- Updates AndroidManifest.xml with the necessary permissions for scanning.