### PR TITLE
feat: Add detailed error reasons for pairing failures

### DIFF
--- a/app/src/main/java/com/gorhaf/excellentwifi/BluetoothFragment.kt
+++ b/app/src/main/java/com/gorhaf/excellentwifi/BluetoothFragment.kt
@@ -107,8 +107,10 @@ class BluetoothFragment : Fragment() {
                         Toast.makeText(context, "Pairing with ${device?.name ?: device?.address}...", Toast.LENGTH_SHORT).show()
                     }
                     BluetoothDevice.BOND_NONE -> {
-                        Log.d(TAG, "Device ${device?.address} not bonded.")
-                        Toast.makeText(context, "Pairing failed with ${device?.name ?: device?.address}", Toast.LENGTH_SHORT).show()
+                        val reason = intent.getIntExtra(BluetoothDevice.EXTRA_REASON, BluetoothDevice.ERROR)
+                        val reasonString = getBondFailureReason(reason)
+                        Log.e(TAG, "Device ${device?.address} not bonded. Reason: $reasonString ($reason)")
+                        Toast.makeText(context, "Pairing failed: $reasonString", Toast.LENGTH_LONG).show()
                     }
                 }
             }
@@ -178,6 +180,19 @@ class BluetoothFragment : Fragment() {
         }
 
         checkPermissionAndSetSwitch()
+    }
+
+    private fun getBondFailureReason(reason: Int): String {
+        return when (reason) {
+            BluetoothDevice.REASON_AUTH_CANCELED -> "Authentication Canceled"
+            BluetoothDevice.REASON_AUTH_FAILED -> "Authentication Failed"
+            BluetoothDevice.REASON_AUTH_REJECTED -> "Authentication Rejected"
+            BluetoothDevice.REASON_REMOTE_DEVICE_DOWN -> "Remote Device Down"
+            BluetoothDevice.REASON_DISCOVERY_IN_PROGRESS -> "Discovery in Progress"
+            BluetoothDevice.REASON_REMOTE_USER_TERMINATED_CONNECTION -> "Remote User Terminated Connection"
+            BluetoothDevice.REASON_LOCAL_HOST_TERMINATED_CONNECTION -> "Local Host Terminated Connection"
+            else -> "Unknown Reason ($reason)"
+        }
     }
 
     private fun checkPermissionsAndScan() {


### PR DESCRIPTION
- Enhances the `bondStateReceiver` to check for `BluetoothDevice.EXTRA_REASON` when a pairing attempt fails.
- Adds a helper function to convert the reason code into a human-readable string.
- Updates the Toast message for pairing failures to be more specific and helpful to the user (e.g., "Authentication Failed," "Remote device down").