### PR TITLE
fix: Correctly update device names during Bluetooth scan

### DIFF
--- a/app/src/main/java/com/gorhaf/excellentwifi/BluetoothFragment.kt
+++ b/app/src/main/java/com/gorhaf/excellentwifi/BluetoothFragment.kt
@@ -80,11 +80,18 @@ class BluetoothFragment : Fragment() {
                         val deviceName = it.name ?: "Unknown Device"
                         val deviceInfo = "$deviceName\n${it.address}\nRSSI: $rssi dBm"
                         Log.d(TAG, "Device found: $deviceInfo")
-                        if (!discoveredDeviceObjects.contains(it)) {
+                        val existingDeviceIndex = discoveredDeviceObjects.indexOf(it)
+                        if (existingDeviceIndex != -1) {
+                            // Device already exists, update it
+                            Log.d(TAG, "Updating existing device at index $existingDeviceIndex")
+                            discoveredDevices[existingDeviceIndex] = deviceInfo
+                        } else {
+                            // New device, add it
+                            Log.d(TAG, "Adding new device")
                             discoveredDevices.add(deviceInfo)
                             discoveredDeviceObjects.add(it)
-                            deviceListAdapter.notifyDataSetChanged()
                         }
+                        deviceListAdapter.notifyDataSetChanged()
                     }
                 }
             }


### PR DESCRIPTION
- Modifies the discovery receiver to handle cases where a device is found multiple times.
- If a discovered device is already in the list, its information (including the friendly name) is now updated instead of being ignored.
- This fixes a bug where the UI would show a stale or garbled temporary name while the logs showed the correct, resolved name.